### PR TITLE
link cards are rendering

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -96,6 +96,13 @@ button {
   width: 33%;
 }
 
+.link {
+  width: 200px;
+  height: 200px;
+  border: 2px solid red;
+  margin: 10px;
+}
+
 .page-break {
   height: 0px;
   width: 80%;

--- a/server.js
+++ b/server.js
@@ -41,9 +41,7 @@ app.get('/api/v1/folders', (req, res) => {
 app.get('/api/v1/links', (req, res) => {
   database('links').select()
     .then((links) => {
-      console.log(links);
       if(links.length) {
-        console.log('FIRE!');
         res.status(200).json(links)
       } else {
         res.status(404).json({
@@ -60,7 +58,8 @@ app.get('/api/v1/links', (req, res) => {
 
 app.post('/api/v1/links', (req, res) => {
   const link = req.body
-
+  console.log('OH MAN A LINK', link);
+  console.log('OH MAN A request', req.body);
   for(let requiredParameter of ['url', 'folder']) {
     if(!link[requiredParameter]) {
       return res.status(422).json({
@@ -80,17 +79,26 @@ app.post('/api/v1/links', (req, res) => {
     })
 })
 
-app.delete('/api/v1/links/:folder', (req, res) => {
+app.delete('/api/v1/links/folder/:folder', (req, res) => {
   const { folder } = req.params
   database('links').where('folder', folder).del()
-  .then(() => {
-    res.sendStatus(200)
-  })
-  .catch(error => {
-    res.sendStatus(500)
-  })
+    .then(() => {
+      res.sendStatus(200)
+    })
+    .catch(error => {
+      res.sendStatus(500)
+    })
+})
 
-  // database('links').where('folder', req.params.folder).remove()
+app.delete('/api/v1/links/:id', (req, res) => {
+  const { id } = req.params
+  database('links').where('id', id).del()
+    .then(() => {
+      res.sendStatus(200)
+    })
+    .catch(error => {
+      res.sendStatus(500)
+    })
 })
 
 app.listen(app.get('port'), () => {  //GET request is sent to this root/location and defining the response sent


### PR DESCRIPTION
Yo dude, did a bunch of simple shit. 

Recreated essentially the the same card for the Links as the Folders currently have, and now clicking on the folders will filter through the link cards by folder property.

Cloned the delete button exactly, and clicking it will remove the link from the screen, but not the database or the local array. Gotta touch that up.

Made a post request at the end of the create new link function but the thing doesn't want to work. It sends information, but there's a disconnect somewhere between the sending and the database reception.

Also switched the id for the initial folder creation to a counter rather than the Date.now().  The damn thing works quick enough that most of the folders are created during the same millisecond and end up with the same ID, making deleting wonky balls.  This wasn't a problem 15 years ago.

